### PR TITLE
Change bucket type to int

### DIFF
--- a/src/erl_optics.app.src
+++ b/src/erl_optics.app.src
@@ -13,7 +13,6 @@
     erl_optics_lens,
     erl_optics_nif
   ]},
-
   {maintainers, []},
   {licenses, ["Apache 2.0"]},
   {links, []}

--- a/src/erl_optics_lens.erl
+++ b/src/erl_optics_lens.erl
@@ -20,7 +20,7 @@
     update/2
 ]).
 
--type histo_buckets() :: list(float()).
+-type histo_buckets() :: list(tuple()).
 
 -record(quantile_args, {
     adjustment_value = undefined :: float(),
@@ -83,7 +83,7 @@ gauge(Name) when is_binary(Name) ->
     #lens{name = Name, type = gauge, f = Fun}.
 
 
--spec histo(lens_name(), list(float())) -> lens().
+-spec histo(lens_name(), list(integer())) -> lens().
 
 histo(Name, Buckets) when is_binary(Name) ->
     Fun = fun(Val) -> erl_optics:histo_inc(Name, Val) end,

--- a/test/erl_optics_test_model.erl
+++ b/test/erl_optics_test_model.erl
@@ -48,17 +48,30 @@ add_lens(Lens, Model = #model{lenses = Lenses, lens_state = State}) ->
 
 
 determine_histo_key(Event, Keys) ->
-    Keys2 = lists:dropwhile(fun(Key) -> Key < Event end, Keys),
-    KeysLen = length(Keys),
-    Keys2Len = length(Keys2),
-    case Keys2Len of
-        0 ->
-            above;
-        KeysLen ->
-            below;
-        _N ->
-            lists:nth(KeysLen - Keys2Len, Keys)
+    Tuple = lists:search(fun(Key) ->
+        {A, B} = Key,
+        Bigger = Event >= A,
+        Smaller = Event < B,
+        Bigger and Smaller
+        end, Keys),
+    case Tuple of
+        {value, Key} ->
+            Key;
+        _ -> above_or_below(Event, Keys)
     end.
+
+above_or_below(Event, Keys) ->
+    Above = lists:dropwhile(fun(Key) ->
+        {Min, Max} = Key,
+        Event < Max end, Keys),
+    case Above of
+        [] ->
+            below;
+        _ ->
+            above
+    end.
+
+
 
 
 -spec do(op(), model()) -> model().
@@ -97,17 +110,29 @@ percentile(Lst, N) ->
 
 populate_histo(Events, Buckets) ->
     Map1 = #{above => 0, below => 0},
-    Keys = lists:sort(Buckets),
+    Bucket_tuples = buckets_to_tuples(Buckets),
+    Keys = lists:sort(Bucket_tuples),
     Map2 = lists:foldl(fun(Bucket, Acc) -> Acc#{Bucket => 0} end, Map1, Keys),
     Map3 = lists:foldl(fun(Event, Acc) ->
         Key = determine_histo_key(Event, Keys),
         #{Key := Val} = Acc,
         Acc#{Key => Val + 1}
     end, Map2, Events),
-    LastBucket = lists:last(Buckets),
-    {V, Map4 = #{above := Above}} = maps:take(LastBucket, Map3),
-    Map4#{above => Above + V}.
+    Map3.
 
+
+buckets_to_tuples(Buckets)->
+    Sorted_buckets = lists:sort(Buckets),
+    buckets_to_tuples(Sorted_buckets, []).
+
+buckets_to_tuples([], Acc) ->
+    Acc;
+buckets_to_tuples([_|[]], Acc) ->
+    Acc;
+buckets_to_tuples(Buckets, Acc) ->
+    [A | Rest] = Buckets,
+    [B | _] = Rest,
+    buckets_to_tuples(Rest, [{A, B}| Acc]).
 
 read_lens() ->
     fun(Lens, Acc) -> read_lens(Lens, Acc) end.

--- a/test/erl_optics_test_utils.erl
+++ b/test/erl_optics_test_utils.erl
@@ -5,7 +5,7 @@
 ]).
 
 seq(Lenses, Lst) ->
-    erl_optics:start(<<"">>, Lenses),
+    erl_optics:start(<<"test">>, Lenses),
     Returns = lists:map(fun(Evt) ->
         case catch do(Evt) of
             ok -> ok;
@@ -40,8 +40,8 @@ read_lenses(Lenses) ->
     {ok, PollMap} = erl_optics:poll(),
     lists:foldl(fun (Lens, Acc) ->
         Name = erl_optics_lens:name(Lens),
-        Val = maps:get(Name, PollMap),
-        case erl_optics_lens:type(Lens) of
+        {Type, Val} = maps:get({<<"test">>, Name}, PollMap),
+        case Type of
             counter ->
                 Acc#{Name => Val};
             dist ->

--- a/test/prop_base.erl
+++ b/test/prop_base.erl
@@ -53,7 +53,7 @@ event(Lenses) ->
     ]).
 
 
-histo_buckets(Len) -> vector(Len, non_neg_float()).
+histo_buckets(Len) -> vector(Len, non_neg_integer()).
 
 
 lens() ->
@@ -117,5 +117,3 @@ seq() ->
         UniqueLenses = maps:values(Map),
         {UniqueLenses, non_empty(list(event(maps:values(Map))))}
     end).
-
-


### PR DESCRIPTION
These changes are made to stay compatible with optics, in which the type for histo bucket has been changed from double to uint64.