### PR TITLE
Add poller prefix and change histo type

### DIFF
--- a/c_src/erl_optics.c
+++ b/c_src/erl_optics.c
@@ -249,7 +249,7 @@ static ERL_NIF_TERM eo_histo_alloc(
     if (!enif_get_list_length(env, argv[2], &buckets_len))
         return ERROR("get_list_length");
 
-    double *buckets = enif_alloc(buckets_len * sizeof(double));
+    uint64_t *buckets = enif_alloc(buckets_len * sizeof(uint64_t));
     if (!buckets) return ERROR("enif_alloc");
 
     ERL_NIF_TERM head, tail;
@@ -257,7 +257,7 @@ static ERL_NIF_TERM eo_histo_alloc(
 
     size_t i = 0;
     do {
-        assert(enif_get_double(env, head, &buckets[i]));
+        assert(enif_get_uint64(env, head, &buckets[i]));
         ++i;
     } while(enif_get_list_cell(env, tail, &head, &tail));
 
@@ -470,7 +470,9 @@ static void backend_eo (void *ctx, enum optics_poll_type type, const struct opti
     enif_make_map_put(m->env, map, atom_above, above, &map);
 
     for(size_t i = 0; i < histo.buckets_len - 1; ++i) {
-      ERL_NIF_TERM k = enif_make_double(m->env, histo.buckets[i]);
+      ERL_NIF_TERM k0 = enif_make_uint64(m->env, histo.buckets[i]);
+      ERL_NIF_TERM k1 = enif_make_uint64(m->env, histo.buckets[i + 1]);
+      ERL_NIF_TERM k = enif_make_tuple2(m->env, k0, k1);
       ERL_NIF_TERM v = enif_make_uint64(m->env, histo.counts[i]);
       enif_make_map_put(m->env, map, k, v, &map);
     }

--- a/c_src/erl_optics.c
+++ b/c_src/erl_optics.c
@@ -12,6 +12,11 @@ static ERL_NIF_TERM atom_quantile;
 static ERL_NIF_TERM atom_sample;
 static ERL_NIF_TERM atom_sample_count;
 static ERL_NIF_TERM atom_count;
+static ERL_NIF_TERM atom_counter;
+static ERL_NIF_TERM atom_gauge;
+static ERL_NIF_TERM atom_dist;
+static ERL_NIF_TERM atom_quantile;
+static ERL_NIF_TERM atom_histo;
 
 static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info) {
     atom_ok = enif_make_atom(env, "ok");
@@ -26,6 +31,11 @@ static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info) {
     atom_sample = enif_make_atom(env, "sample");
     atom_sample_count = enif_make_atom(env, "sample_count");
     atom_count = enif_make_atom(env, "count");
+    atom_counter = enif_make_atom(env, "counter");
+    atom_gauge = enif_make_atom(env, "gauge");
+    atom_dist = enif_make_atom(env, "dist");
+    atom_histo = enif_make_atom(env, "histo");
+    atom_quantile = enif_make_atom(env, "quantile");
     return 0;
 }
 
@@ -387,25 +397,34 @@ static void backend_eo (void *ctx, enum optics_poll_type type, const struct opti
 
   struct map_ctx *m = (struct map_ctx *) ctx;
 
+  ERL_NIF_TERM name;
+  ERL_NIF_TERM prefix;
   ERL_NIF_TERM key;
-  unsigned char * bin_key;
+  unsigned char * bin_name;
+  unsigned char * bin_prefix;
+
+  size_t name_len = strlen(poll->key);
   size_t prefix_len = strlen(poll->prefix);
-  size_t key_len = strlen(poll->key);
-  size_t full_key_len = prefix_len + key_len + 1;
-  bin_key = enif_make_new_binary(m->env, full_key_len, &key);
-  memcpy(bin_key, poll->prefix, prefix_len);
-  bin_key[prefix_len] = '.';
-  memcpy(bin_key + prefix_len + 1, poll->key, key_len);
+
+  bin_name = enif_make_new_binary(m->env, name_len, &name);
+  memcpy(bin_name, poll->key, name_len);
+  bin_prefix = enif_make_new_binary(m->env, prefix_len, &prefix);
+  memcpy(bin_prefix, poll->prefix, prefix_len);
+  key = enif_make_tuple2(m->env, prefix, name);
 
   ERL_NIF_TERM val;
 
   switch(poll->type) {
   case optics_counter :{
-    val = enif_make_uint64(m->env, poll->value.counter);
+    val = enif_make_tuple2(m->env,
+        atom_counter,
+        enif_make_uint64(m->env, poll->value.counter));
     break;
   }
   case optics_gauge :{
-    val = enif_make_double(m->env, poll->value.gauge);
+    val = enif_make_tuple2(m->env,
+        atom_gauge,
+        enif_make_double(m->env, poll->value.gauge));
     break;
   }
   case optics_quantile :{
@@ -415,12 +434,13 @@ static void backend_eo (void *ctx, enum optics_poll_type type, const struct opti
     ERL_NIF_TERM sample = enif_make_double(m->env, oq.sample);
     ERL_NIF_TERM sample_count = enif_make_uint64(m->env, oq.sample_count);
     ERL_NIF_TERM count = enif_make_uint64(m->env, oq.count);
+    ERL_NIF_TERM map = enif_make_new_map(m->env);
 
-    val = enif_make_new_map(m->env);
-    enif_make_map_put(m->env, val, atom_quantile, quantile, &val);
-    enif_make_map_put(m->env, val, atom_sample, sample, &val);
-    enif_make_map_put(m->env, val, atom_sample_count, sample_count, &val);
-    enif_make_map_put(m->env, val, atom_count, count, &val);
+    enif_make_map_put(m->env, map, atom_quantile, quantile, &map);
+    enif_make_map_put(m->env, map, atom_sample, sample, &map);
+    enif_make_map_put(m->env, map, atom_sample_count, sample_count, &map);
+    enif_make_map_put(m->env, map, atom_count, count, &map);
+    val = enif_make_tuple2(m->env, atom_quantile, map);
     break;
   }
   case optics_dist :{
@@ -431,12 +451,13 @@ static void backend_eo (void *ctx, enum optics_poll_type type, const struct opti
     ERL_NIF_TERM v_p99 = enif_make_double(m->env, dist.p99);
     ERL_NIF_TERM v_max = enif_make_double(m->env, dist.max);
 
-    val = enif_make_new_map(m->env);
-    enif_make_map_put(m->env, val, atom_n, v_n, &val);
-    enif_make_map_put(m->env, val, atom_p50, v_p50, &val);
-    enif_make_map_put(m->env, val, atom_p90, v_p90, &val);
-    enif_make_map_put(m->env, val, atom_p99, v_p99, &val);
-    enif_make_map_put(m->env, val, atom_max, v_max, &val);
+    ERL_NIF_TERM map = enif_make_new_map(m->env);
+    enif_make_map_put(m->env, map, atom_n, v_n, &map);
+    enif_make_map_put(m->env, map, atom_p50, v_p50, &map);
+    enif_make_map_put(m->env, map, atom_p90, v_p90, &map);
+    enif_make_map_put(m->env, map, atom_p99, v_p99, &map);
+    enif_make_map_put(m->env, map, atom_max, v_max, &map);
+    val = enif_make_tuple2(m->env, atom_dist, map);
     break;
   }
   case optics_histo :{
@@ -444,20 +465,19 @@ static void backend_eo (void *ctx, enum optics_poll_type type, const struct opti
     ERL_NIF_TERM below = enif_make_uint64(m->env, histo.below);
     ERL_NIF_TERM above = enif_make_uint64(m->env, histo.above);
 
-    val = enif_make_new_map(m->env);
-    enif_make_map_put(m->env, val, atom_below, below, &val);
-    enif_make_map_put(m->env, val, atom_above, above, &val);
+    ERL_NIF_TERM map = enif_make_new_map(m->env);
+    enif_make_map_put(m->env, map, atom_below, below, &map);
+    enif_make_map_put(m->env, map, atom_above, above, &map);
 
     for(size_t i = 0; i < histo.buckets_len - 1; ++i) {
       ERL_NIF_TERM k = enif_make_double(m->env, histo.buckets[i]);
       ERL_NIF_TERM v = enif_make_uint64(m->env, histo.counts[i]);
-      enif_make_map_put(m->env, val, k, v, &val);
+      enif_make_map_put(m->env, map, k, v, &map);
     }
-
+    val = enif_make_tuple2(m->env, atom_histo, map);
     break;
   }
   }
-
   enif_make_map_put( m->env , m->map, key, val, &(m->map));
 }
 

--- a/src/erl_optics.app.src
+++ b/src/erl_optics.app.src
@@ -13,7 +13,6 @@
     erl_optics_lens,
     erl_optics_nif
   ]},
-
   {maintainers, []},
   {licenses, ["Apache 2.0"]},
   {links, []}

--- a/src/erl_optics_lens.erl
+++ b/src/erl_optics_lens.erl
@@ -18,7 +18,7 @@
     update/2
 ]).
 
--type histo_buckets() :: list(float()).
+-type histo_buckets() :: list({integer(), integer()}).
 
 -record(quantile_args, {
     adjustment_value = undefined :: float(),
@@ -81,7 +81,7 @@ gauge(Name) when is_binary(Name) ->
     #lens{name = Name, type = gauge, f = Fun}.
 
 
--spec histo(lens_name(), list(float())) -> lens().
+-spec histo(lens_name(), list(integer())) -> lens().
 
 histo(Name, Buckets) when is_binary(Name) ->
     Fun = fun(Val) -> erl_optics:histo_inc(Name, Val) end,

--- a/src/erl_optics_lens.erl
+++ b/src/erl_optics_lens.erl
@@ -11,8 +11,6 @@
     histo/2,
     name/1,
     quantile/4,
-    multiple_quantile/4,
-    triple_quantile/3,
     quantile_adjustment_value/1,
     quantile_estimate/1,
     quantile_target/1,
@@ -105,21 +103,6 @@ quantile(Name, Target, Estimate, AdjVal) ->
     },
     Fun = fun(Val) -> erl_optics:quantile_update(Name, Val) end,
     #lens{name = Name, type = quantile, f = Fun, ext = Ext}.
-
-
--spec multiple_quantile(binary(), list(), float(), float()) -> list().
-
-multiple_quantile(Name, KeyTargetList, Estimate, AdjVal)->
-    lists:map(fun({Key, Target}) -> erl_optics_lens:quantile(list_to_binary([Name, Key]), Target, Estimate, AdjVal) end, KeyTargetList).
-
--spec triple_quantile(lens_name(), float(), float()) -> list().
-
-triple_quantile(Name, Estimate, AdjVal)->
-    [quantile(list_to_binary([Name, <<".q50">>]), 0.5, Estimate, AdjVal),
-     quantile(list_to_binary([Name, <<".q95">>]), 0.95, Estimate, AdjVal),
-     quantile(list_to_binary([Name, <<".q99">>]), 0.99, Estimate, AdjVal)].
-
-
 
 
 -spec quantile_adjustment_value(lens()) -> float().

--- a/test/erl_optics_test_utils.erl
+++ b/test/erl_optics_test_utils.erl
@@ -40,8 +40,8 @@ read_lenses(Lenses) ->
     {ok, PollMap} = erl_optics:poll(),
     lists:foldl(fun (Lens, Acc) ->
         Name = erl_optics_lens:name(Lens),
-        Val = maps:get(list_to_binary([<<"test">>, $., Name]), PollMap),
-        case erl_optics_lens:type(Lens) of
+        {Type, Val} = maps:get({<<"test">>, Name}, PollMap),
+        case Type of
             counter ->
                 Acc#{Name => Val};
             dist ->

--- a/test/prop_base.erl
+++ b/test/prop_base.erl
@@ -17,7 +17,6 @@ prop_test() ->
 check({Lenses, Seq}) ->
     ErlModel = erl_optics_test_model:seq(Lenses, Seq),
     CModel = erl_optics_test_utils:seq(Lenses, Seq),
-    %io:format("~p~n", [#{erl => ErlModel, c => CModel, seq => Seq, lenses => Lenses}]),
     ErlModel =:= CModel.
 
 
@@ -53,7 +52,7 @@ event(Lenses) ->
     ]).
 
 
-histo_buckets(Len) -> vector(Len, non_neg_float()).
+histo_buckets(Len) -> vector(Len, non_neg_integer()).
 
 
 lens() ->
@@ -117,5 +116,3 @@ seq() ->
         UniqueLenses = maps:values(Map),
         {UniqueLenses, non_empty(list(event(maps:values(Map))))}
     end).
-
-


### PR DESCRIPTION
This changes the poller to take the optics namespace into consideration, and applies the necessary changes to stay compatible with optics' change of histo bucket type from double to int.