### PR TITLE
Fix/foil not started

### DIFF
--- a/src/erl_optics.erl
+++ b/src/erl_optics.erl
@@ -33,8 +33,13 @@ counter_inc(Key) ->
 -spec counter_inc(binary(), integer()) -> ok | {error, term()}.
 
 counter_inc(Key, Amt) ->
-    {ok, Ptr} = get_lens(Key),
-    erl_optics_nif:counter_inc(Ptr, Amt).
+    case get_lens(Key) of
+        {ok, Ptr} ->
+            erl_optics_nif:counter_inc(Ptr, Amt);
+        {error, Msg} ->
+            {error, Msg}
+    end.
+
 
 
 -spec counter_inc_alloc(binary()) -> ok | {error, term()}.
@@ -54,8 +59,12 @@ counter_inc_alloc(Key, Amt)->
 -spec dist_record(binary(), float()) -> ok | {error, term()}.
 
 dist_record(Key, Val) ->
-    {ok, Ptr} = get_lens(Key),
-    erl_optics_nif:dist_record(Ptr, Val).
+    case get_lens(Key) of
+        {ok, Ptr} ->
+            erl_optics_nif:dist_record(Ptr, Val);
+        {error, Msg} ->
+            {error, Msg}
+    end.
 
 -spec dist_record_alloc(binary(), float()) -> ok | {error, term()}.
 
@@ -83,8 +92,12 @@ gauge_set(Key, Val) when is_integer(Val) ->
     gauge_set(Key, float(Val));
 
 gauge_set(Key, Val) ->
-    {ok, Ptr} = get_lens(Key),
-    erl_optics_nif:gauge_set(Ptr, Val).
+    case get_lens(Key) of
+        {ok, Ptr} ->
+            erl_optics_nif:gauge_set(Ptr, Val);
+        {error, Msg} ->
+            {error, Msg}
+    end.
 
 -spec gauge_set_alloc(binary(), number()) -> ok | {error, term()}.
 
@@ -104,8 +117,12 @@ histo_inc(Key, Val) when is_integer(Val) ->
     histo_inc(Key, float(Val));
 
 histo_inc(Key, Val) ->
-    {ok, Ptr} = get_lens(Key),
-    erl_optics_nif:histo_inc(Ptr, Val).
+     case get_lens(Key) of
+         {ok, Ptr} ->
+             erl_optics_nif:histo_inc(Ptr, Val);
+         {error, Msg} ->
+             {error, Msg}
+     end.
 
 
 -spec lens_update(erl_optics_lens:t(), number()) -> ok | {error, term()}.
@@ -129,8 +146,12 @@ quantile_update(Key, Val) when is_integer(Val) ->
     quantile_update(Key, float(Val));
 
 quantile_update(Key, Val) ->
-    {ok, Ptr} = get_lens(Key),
-    erl_optics_nif:quantile_update(Ptr, Val).
+    case get_lens(Key) of
+        {ok, Ptr} ->
+            erl_optics_nif:quantile_update(Ptr, Val);
+        {error, Msg} ->
+            {error, Msg}
+    end.
 
 
 -spec quantile_update_timing_now(binary(), erlang:timestamp()) -> ok | {error, term()}.

--- a/src/erl_optics.erl
+++ b/src/erl_optics.erl
@@ -56,7 +56,9 @@ counter_inc_alloc(Key, Amt)->
     erl_optics_nif:lens_close(Ptr).
 
 
--spec dist_record(binary(), float()) -> ok | {error, term()}.
+-spec dist_record(binary(), number()) -> ok | {error, term()}.
+dist_record(Key, Val) when is_integer(Val) ->
+    dist_record(Key, float(Val));
 
 dist_record(Key, Val) ->
     case get_lens(Key) of

--- a/src/erl_optics_lens.erl
+++ b/src/erl_optics_lens.erl
@@ -88,6 +88,7 @@ histo(Name, Buckets) when is_binary(Name) ->
     #lens{name = Name, type = histo, f = Fun, ext = Buckets}.
 
 
+
 -spec name(lens()) -> binary().
 
 name(#lens{name = Name}) -> Name.

--- a/test/prop_base.erl
+++ b/test/prop_base.erl
@@ -17,6 +17,7 @@ prop_test() ->
 check({Lenses, Seq}) ->
     ErlModel = erl_optics_test_model:seq(Lenses, Seq),
     CModel = erl_optics_test_utils:seq(Lenses, Seq),
+    %io:format("~p~n", [#{erl => ErlModel, c => CModel, seq => Seq, lenses => Lenses}]),
     ErlModel =:= CModel.
 
 
@@ -54,6 +55,9 @@ event(Lenses) ->
 
 histo_buckets(Len) -> vector(Len, non_neg_integer()).
 
+no_single_histo_buckets(Len) ->
+    ?SUCHTHAT(Buckets, histo_buckets(Len), length(lists:usort(Buckets)) > 2).
+
 
 lens() ->
     ?LET([Name, Type], [lens_name(), erl_optics_lens:lens_type()], begin
@@ -65,7 +69,7 @@ lens() ->
             gauge ->
                 erl_optics_lens:gauge(Name);
             histo ->
-                ?LAZY(?LET([Buckets], [histo_buckets(8)],
+                ?LAZY(?LET([Buckets], [no_single_histo_buckets(8)],
                     erl_optics_lens:histo(Name, lists:usort(Buckets))));
             quantile ->
                 ?LAZY(?LET([T, E, A], [non_neg_float(), non_neg_float(), non_neg_float()],


### PR DESCRIPTION
Handles the situation where get_lens would return an unhandled value because foil is not started.

Allows integers to be used with dist instead of strictly float.