### PR TITLE
Fix the compile-time warnings

### DIFF
--- a/c_src/erl_optics.c
+++ b/c_src/erl_optics.c
@@ -479,6 +479,8 @@ static void backend_eo (void *ctx, enum optics_poll_type type, const struct opti
     val = enif_make_tuple2(m->env, atom_histo, map);
     break;
   }
+  default:
+    return;
   }
   enif_make_map_put( m->env , m->map, key, val, &(m->map));
 }

--- a/test/erl_optics_test_model.erl
+++ b/test/erl_optics_test_model.erl
@@ -62,7 +62,7 @@ determine_histo_key(Event, Keys) ->
 
 above_or_below(Event, Keys) ->
     Above = lists:dropwhile(fun(Key) ->
-        {Min, Max} = Key,
+        {_Min, Max} = Key,
         Event < Max end, Keys),
     case Above of
         [] ->


### PR DESCRIPTION
This handles the case where a term could potentially be declared and returned without being assigned a value, and removes a warning for an unused variable in the tests.