### PR TITLE
Feature/foil as cache

### DIFF
--- a/include/erl_optics.hrl
+++ b/include/erl_optics.hrl
@@ -3,8 +3,13 @@
 -define(ENV_HOSTNAME, hostname).
 -define(ENV_PORT, port).
 -define(ENV_INTERVAL, interval).
+-define(ENV_FOIL_RELOAD_INTERVAL, foil_reload_interval).
 -define(ENV_MODE, mode).
+-define(ENV_FOIL_NAMESPACE, foil_namespace).
+-define(DEFAULT_FOIL_NAMESPACE, erl_optics).
+-define(NS, ?ENV(?ENV_FOIL_NAMESPACE, ?DEFAULT_FOIL_NAMESPACE)).
 -define(DEFAULT_MODE, blank).
 -define(DEFAULT_PORT, 1055).
 -define(DEFAULT_HOSTNAME, "localhost").
 -define(DEFAULT_INTERVAL, 10000).
+-define(DEFAULT_FOIL_RELOAD_INTERVAL, 1000).

--- a/src/erl_optics_foil_server.erl
+++ b/src/erl_optics_foil_server.erl
@@ -1,0 +1,100 @@
+-module(erl_optics_foil_server).
+-include("erl_optics.hrl").
+
+-behaviour(gen_server).
+
+-export([
+    init/1,
+    handle_cast/2,
+    handle_call/3,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
+
+-export([
+    start_link/0,
+    add_lens/2,
+    stop/0
+]).
+
+-define(SERVER, ?MODULE).
+
+-record(state, {
+    new_lenses  :: list() | undefined,
+    timer_ref :: timer:tref() | undefined | none
+}).
+
+%%%=========
+%%% API
+%%%=========
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+stop() ->
+    gen_server:cast(?SERVER, stop).
+
+%%%==========
+%%% Callbacks
+%%%==========
+
+init(_) ->
+    ets:new(erl_optics_ets, [named_table, public, {write_concurrency, false}, {read_concurrency, true}]),
+    {ok, #state{new_lenses = [], timer_ref = none}, 0}.
+
+handle_cast({add_lens, Lens}, State) ->
+    case State#state.timer_ref of
+        none ->
+            Tref = timer:send_after(?ENV(?ENV_FOIL_RELOAD_INTERVAL,
+                ?DEFAULT_FOIL_RELOAD_INTERVAL), reload_foil);
+        _ ->
+            Tref = State#state.timer_ref
+    end,
+    {noreply, #state{new_lenses =  [Lens | State#state.new_lenses],
+        timer_ref = Tref}};
+handle_cast(stop, State) ->
+    {stop, normal, State};
+handle_cast(_, State) ->
+    {noreply, State}.
+
+handle_call(reload_foil, _From, State) ->
+    maybe_reload_foil(State),
+    {reply, ok, #state{new_lenses = []}};
+handle_call(_, _From, State) ->
+    {reply, {error, undefined_call}, State}.
+
+handle_info(reload_foil, State) ->
+    maybe_reload_foil(State),
+    timer:cancel(State#state.timer_ref),
+    {noreply, #state{new_lenses = [], timer_ref = none}};
+handle_info(_, State) ->
+    {noreply, State}.
+
+
+%%% API
+
+add_lens(Key, Ptr) ->
+    gen_server:cast(?SERVER, {add_lens, {Key, Ptr}}).
+
+terminate(_Reason, State) ->
+    timer:cancel(State#state.timer_ref),
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%% private
+
+insert_lens({Key, Ptr}) ->
+    foil:insert(?NS, Key, Ptr).
+
+maybe_reload_foil(State) ->
+    Lenses = State#state.new_lenses,
+    case Lenses of
+        [] ->
+            ok;
+        _ ->
+            lists:map(fun insert_lens/1, Lenses),
+            foil:load(?NS)
+    end.


### PR DESCRIPTION
This removes the need to declare counter, gauge and dist lenses in advance. 

When calling counter_inc/1, counter_inc/2, gauge_set/2, or dist_record/2, a search is made in the foil table. On success, the appropriate optics update function is called. Otherwise, the lens is updated via alloc_get, and the returning pair {Key, Pointer} is sent to the erl_optics_foil_server that will store it in a list. When the server casts reload_foil, the new values are added to the table and it is recompiled. 

As a result of this change, the short-lived erl_optics behaviour is now deprecated.

Initial declaration of quantile and histo lenses is still necessary, as these require known initial values. 